### PR TITLE
tbl printing uses update_focus()

### DIFF
--- a/R/tbl-format-header.R
+++ b/R/tbl-format-header.R
@@ -33,7 +33,7 @@ tbl_format_header <- function(x, setup, ...) {
 #' @export
 tbl_format_header.tbl <- function(x, setup, ...) {
   named_header <- setup$tbl_sum
-  focus <- attr(x, "pillar_focus")
+  focus <- setup$focus
   if (!is.null(focus)) {
     named_header <- c(named_header, "Focus columns" = collapse(tick_if_needed(focus)))
   }

--- a/R/tbl-format-setup.R
+++ b/R/tbl-format-setup.R
@@ -130,6 +130,8 @@ tbl_format_setup.tbl <- function(x, width, ...,
     rows_missing <- 0L
   }
 
+  focus <- update_focus(focus, x)
+
   # Header
   tbl_sum <- tbl_sum(x)
 
@@ -169,8 +171,20 @@ tbl_format_setup.tbl <- function(x, width, ...,
     extra_cols = extra_cols,
     extra_cols_total = extra_cols_total,
     max_footer_lines = max_footer_lines,
-    abbrev_cols = abbrev_cols
+    abbrev_cols = abbrev_cols,
+    focus = focus
   )
+}
+
+update_focus <- function(focus, x) {
+  if (is_null(focus)) {
+    focus <- attr(x, "pillar_focus")
+  }
+  focus <- intersect(focus, names(x))
+  if (is_empty(focus)) {
+    return(NULL)
+  }
+  focus
 }
 
 #' Construct a setup object for formatting
@@ -207,7 +221,8 @@ new_tbl_format_setup <- function(x, df, width, tbl_sum, body,
                                  rows_missing, rows_total,
                                  extra_cols, extra_cols_total,
                                  max_footer_lines,
-                                 abbrev_cols) {
+                                 abbrev_cols,
+                                 focus) {
   trunc_info <- list(
     x = x,
     df = df,
@@ -219,7 +234,8 @@ new_tbl_format_setup <- function(x, df, width, tbl_sum, body,
     extra_cols = extra_cols,
     extra_cols_total = extra_cols_total,
     max_footer_lines = max_footer_lines,
-    abbrev_cols = abbrev_cols
+    abbrev_cols = abbrev_cols,
+    focus = focus
   )
 
   structure(trunc_info, class = "pillar_tbl_format_setup")


### PR DESCRIPTION
So that the focus columns are updated according to (i.e. intersect()ed with) the current names

``` r
df <- tibble::as_tibble(as.list(setNames(letters, letters)))
attr(df, "pillar_focus") <- c('x', 'y')
df |> 
  dplyr::select(a)
#> [90m# A tibble: 1 × 1[39m
#>   a    
#>   [3m[90m<chr>[39m[23m
#> [90m1[39m a
```

In main this errors:

``` r
df <- tibble::as_tibble(as.list(setNames(letters, letters)))
attr(df, "pillar_focus") <- c('x', 'y')
df |> 
  dplyr::select(a)
#> Error in ctl_colonnade(df, has_row_id = if (.row_names_info(x) > 0) "*" else TRUE, : all(focus %in% names(x)) is not TRUE
```

<sup>Created on 2024-01-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
